### PR TITLE
Updates for FreeRTOS submodule

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,7 +26,4 @@ runs:
         arduino-cli core install adafruit:samd
         arduino-cli core install arduino:samd
         arduino-cli lib install Time
-        arduino-cli lib install FreeRTOS_SAMD51
-        echo "#define INCLUDE_xSemaphoreGetMutexHolder 1" >> $HOME/Arduino/libraries/FreeRTOS_SAMD51/src/FreeRTOSConfig.h
-        sed -i '/#define configTOTAL_HEAP_SIZE.*/#define configTOTAL_HEAP_SIZE			( ( size_t ) ( 95 * 1024 ) )/' $HOME/Arduino/libraries/FreeRTOS_SAMD51/src/FreeRTOSConfig.h
       shell: bash


### PR DESCRIPTION
Once all of the changes are merged in at the reference project level, these lines in action.yml will no longer be necessary since FreeRTOS will be included as a submodule. The FreeRTOS config file will also live at the reference project level so there will be no need to change the configTOTAL_HEAP_SIZE macro.